### PR TITLE
remove carriage returns from textarea values

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -33,3 +33,6 @@ services:
     OHMedia\UtilityBundle\Form\Extension\GuessAttributesExtension:
         tags: ['form.type_extension']
         arguments: ['@form.type_guesser.validator']
+
+    OHMedia\UtilityBundle\Form\Extension\TextareaExtension:
+        tags: ['form.type_extension']

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -34,5 +34,5 @@ services:
         tags: ['form.type_extension']
         arguments: ['@form.type_guesser.validator']
 
-    OHMedia\UtilityBundle\Form\Extension\TextareaExtension:
+    OHMedia\UtilityBundle\Form\Extension\RemoveCarriageReturnExtension:
         tags: ['form.type_extension']

--- a/src/Form/Extension/RemoveCarriageReturnExtension.php
+++ b/src/Form/Extension/RemoveCarriageReturnExtension.php
@@ -11,7 +11,7 @@ class RemoveCarriageReturnExtension extends AbstractTypeExtension
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $removeCarriageReturn = function (?string $value): string {
+        $removeCarriageReturn = function (?string $value): ?string {
             if ($value) {
                 $value = str_replace(["\r\n", "\r"], "\n", $value);
             }

--- a/src/Form/Extension/RemoveCarriageReturnExtension.php
+++ b/src/Form/Extension/RemoveCarriageReturnExtension.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class TextareaExtension extends AbstractTypeExtension
+class RemoveCarriageReturnExtension extends AbstractTypeExtension
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/src/Form/Extension/TextareaExtension.php
+++ b/src/Form/Extension/TextareaExtension.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace OHMedia\UtilityBundle\Form\Extension;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\CallbackTransformer;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class TextareaExtension extends AbstractTypeExtension
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $removeCarriageReturn = function (?string $value): string {
+            if ($value) {
+                $value = str_replace(["\r\n", "\r"], "\n", $value);
+            }
+
+            return $value;
+        };
+
+        $builder->addModelTransformer(new CallbackTransformer(
+            $removeCarriageReturn,
+            $removeCarriageReturn,
+        ));
+    }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [TextareaType::class];
+    }
+}


### PR DESCRIPTION
The browser textarea doesn't include carriage returns (`\r` characters) but PHP does. This causes problems when a textarea has a maxlength and it's maxed out with newlines in the value. An extra `\r` character is added per `\n` on the PHP side, causing it to fail BE validation.